### PR TITLE
[HASH] Added Rust API to sha256 hash a file

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -71,6 +71,7 @@ version = "0.0.9"
 dependencies = [
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "zip",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.1.1", features = ["devtools", "dialog-all", "fs-all", "http-all", "path-all", "window-all"] }
 zip = { version = "0.6.3" } # currently uses all features
+sha2 = { version = "0.10" }
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/hash_utils.rs
+++ b/src-tauri/src/hash_utils.rs
@@ -1,0 +1,24 @@
+use std::fs;
+use std::io;
+
+use sha2::Digest;
+use sha2::Sha256;
+use tauri::AppHandle;
+
+use crate::utils::get_allowed_path_with_string_error;
+
+// async (other thread), since it does not care about other stuff
+#[tauri::command]
+pub async fn get_sha256_of_file(app_handle: AppHandle, path: &str) -> Result<String, String> {
+    let source_path = get_allowed_path_with_string_error(&app_handle, path)?;
+
+    let hash_result = || -> Result<String, io::Error> {
+        // source: https://github.com/RustCrypto/hashes
+        let mut file = fs::File::open(&source_path)?;
+        let mut hasher = Sha256::new();
+        io::copy(&mut file, &mut hasher)?;
+        let hash_bytes = hasher.finalize();
+        Ok(format!("{:x}", hash_bytes))
+    }();
+    hash_result.map_err(|error| error.to_string())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,6 +6,7 @@
 mod gui_config;
 mod utils;
 mod zip_utils;
+mod hash_utils;
 
 use std::{sync::Mutex, collections::HashMap, fs::File};
 use tauri::RunEvent;
@@ -31,6 +32,7 @@ fn main() {
             zip_utils::exist_zip_entry,
             zip_utils::get_zip_entry_as_binary,
             zip_utils::get_zip_entry_as_text,
+            hash_utils::get_sha256_of_file,
         ])
 
         // config

--- a/src-tauri/src/zip_utils.rs
+++ b/src-tauri/src/zip_utils.rs
@@ -106,8 +106,9 @@ pub fn close_zip(app_handle: AppHandle, id: usize) -> Result<(), String> {
 }
 
 // careless, overwrites, may leave remains on error
+// async (other thread), since it does not care about other stuff
 #[tauri::command]
-pub fn extract_zip_to_path(app_handle: AppHandle, source: &str, dest: &str) -> Result<(), String> {
+pub async fn extract_zip_to_path(app_handle: AppHandle, source: &str, dest: &str) -> Result<(), String> {
     let source_path = get_allowed_path_with_string_error(&app_handle, source)?;
     let dist_path = get_allowed_path_with_string_error(&app_handle, dest)?;
 

--- a/src/renderer/utils/general-utils.ts
+++ b/src/renderer/utils/general-utils.ts
@@ -1,5 +1,8 @@
 // needs to be used to get the window by identifier
 // source: https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest
+
+import { getSha256OfFile } from './tauri-invoke';
+
 // eslint-disable-next-line import/prefer-default-export
 export async function getHexHashOfString(message: string): Promise<string> {
   const msgUint8 = new TextEncoder().encode(message); // encode as (utf-8) Uint8Array
@@ -9,4 +12,9 @@ export async function getHexHashOfString(message: string): Promise<string> {
     .map((b) => b.toString(16).padStart(2, '0'))
     .join(''); // convert bytes to hex string
   return hashHex;
+}
+
+// uses sha256 of Rust backend
+export async function getHexHashOfFile(path: string): Promise<string> {
+  return getSha256OfFile(path);
 }

--- a/src/renderer/utils/tauri-invoke.ts
+++ b/src/renderer/utils/tauri-invoke.ts
@@ -15,6 +15,7 @@ const TAURI_COMMAND = {
   ZIP_EXIST_ENTRY: 'exist_zip_entry',
   ZIP_GET_ENTRY_AS_BINARY: 'get_zip_entry_as_binary',
   ZIP_GET_ENTRY_AS_TEXT: 'get_zip_entry_as_text',
+  HASH_GET_SHA256_OF_FILE: 'get_sha256_of_file',
 };
 
 export async function setGuiConfigLanguage(lang: string): Promise<void> {
@@ -75,4 +76,8 @@ export async function getZipEntryAsText(
   path: string
 ): Promise<string> {
   return invoke(TAURI_COMMAND.ZIP_GET_ENTRY_AS_TEXT, { id, path });
+}
+
+export async function getSha256OfFile(path: string): Promise<string> {
+  return invoke(TAURI_COMMAND.HASH_GET_SHA256_OF_FILE, { path });
 }


### PR DESCRIPTION
Also made this and the pure zip extract call async, since they are rather self contained functions.

The function for the frontend is `getHexHashOfFile` in `general-utils.ts`.
(The would prefer if most of the funcs in tauri-invoke.ts are never directly called for usage, but only by a function providing it. For abstraction.)