### PR TITLE
[FIX] Fix double onCloseRequested causing issues

### DIFF
--- a/src/renderer/utils/window-utils.ts
+++ b/src/renderer/utils/window-utils.ts
@@ -2,6 +2,7 @@
 // currently it will just take care that only of window can be crated
 // the main (landing) window is ignored)
 
+import { TauriEvent } from '@tauri-apps/api/event';
 import { WebviewWindow, WindowOptions } from '@tauri-apps/api/window';
 import { getHexHashOfString } from './general-utils';
 
@@ -42,9 +43,12 @@ export async function createNewWindow(
   );
 
   // also expects close to go through
-  const unlistenFunc = await webview.onCloseRequested(() => {
-    delete createdWindows[windowName];
-    unlistenFunc();
-  });
+  const unlistenFunc = await webview.listen(
+    TauriEvent.WINDOW_CLOSE_REQUESTED,
+    () => {
+      delete createdWindows[windowName];
+      unlistenFunc();
+    }
+  );
   createdWindows[windowName] = webview;
 }


### PR DESCRIPTION
Caught by accident and related to #20. It only showed up after being build (or it simply was fast enough then to provoke the error).

The main `onCloseRequested` should run async but "synchronous" before the window closes... but it did not.
Apperantly placing a second `onCloseRequested` after the window creation caused issues.
Replacing it with a default listener made it work.

In theory one should actually now look up if this is intended and if not create an issue (or look if it already exists), but I am too lazy.
