### PR TITLE
[CONFIG] Small build config adjustments

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3732,7 +3732,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucp_gui"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "anyhow",
  "dunce",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "ucp_gui"
-version = "0.0.19"
+version = "0.0.20"
 description = "UCP3 GUI"
 authors = ["gynt", "TheRedDaemon"]
 license = ""
-repository = ""
+repository = "https://github.com/UnofficialCrusaderPatch/UCP3-GUI"
 default-run = "ucp_gui"
 edition = "2021"
 rust-version = "1.64"
@@ -34,3 +34,11 @@ default = [ "custom-protocol" ]
 # this feature is used for production builds where `devPath` points to the filesystem
 # DO NOT remove this
 custom-protocol = [ "tauri/custom-protocol" ]
+
+# "recommanded" options for tauri release (https://tauri.app/v1/guides/building/app-size/#rust-build-time-optimizations)
+[profile.release]
+panic = "abort" # Strip expensive panic clean-up logic
+codegen-units = 1 # Compile crates one after another so the compiler can optimize better
+lto = true # Enables link to optimizations
+opt-level = "s" # Optimize for binary size
+strip = true # Remove debug symbols

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,8 +7,7 @@
     "distDir": "../dist"
   },
   "package": {
-    "productName": "UCP3-GUI",
-    "version": "0.0.19"
+    "productName": "UCP3-GUI"
   },
   "tauri": {
     "allowlist": {
@@ -69,6 +68,7 @@
         "icons/icon.ico"
       ],
       "identifier": "ucp.gui.tauri",
+      "publisher": "ucp-team",
       "longDescription": "",
       "macOS": {
         "entitlements": null,
@@ -79,11 +79,16 @@
       },
       "resources": [],
       "shortDescription": "",
-      "targets": "all",
+      "targets": ["nsis", "updater"],
       "windows": {
         "certificateThumbprint": null,
         "digestAlgorithm": "sha256",
-        "timestampUrl": ""
+        "timestampUrl": "",
+        "nsis": {
+          "installMode": "both",
+          "displayLanguageSelector": true,
+          "languages": ["English", "German"]
+        }
       }
     },
     "security": {


### PR DESCRIPTION
- Without Win7 support, not much appears to need changes.
- There are some bigger config changes one could make, like switching to the "isolation" pattern, which apperantly is safer. It read however, like it would require big tests and has some restrictions, so the current one stays.
- Installer customization is put into a ticket.