### PR TITLE
Improve extension modification experience

### DIFF
--- a/src/components/sandbox-menu/sandbox-menu-functions.ts
+++ b/src/components/sandbox-menu/sandbox-menu-functions.ts
@@ -14,6 +14,7 @@ import {
 } from '../../function/configuration/state';
 import { EXTENSION_STATE_REDUCER_ATOM } from '../../function/extensions/state/state';
 import { LANGUAGE_ATOM } from '../../function/gui-settings/settings';
+import { ACTIVE_EXTENSIONS_FULL_ATOM } from '../../function/extensions/state/focus';
 
 export async function getLanguage(): Promise<string> {
   return getStore().get(LANGUAGE_ATOM);
@@ -39,7 +40,7 @@ export function createGetAssetUrlFunction(currentFolder: string) {
 }
 
 export function createReceivePluginPathsFunction(currentFolder: string) {
-  const { activeExtensions } = getStore().get(EXTENSION_STATE_REDUCER_ATOM);
+  const activeExtensions = getStore().get(ACTIVE_EXTENSIONS_FULL_ATOM);
 
   let gameFolder: string | null = null;
   return async (basePath: string, pathPattern: string) => {

--- a/src/components/ucp-tabs/common/importing/import-strategies/tests/import-strategies.invalid.test.ts
+++ b/src/components/ucp-tabs/common/importing/import-strategies/tests/import-strategies.invalid.test.ts
@@ -1048,7 +1048,7 @@ describe('attemptStrategies', () => {
     if (strategyResult.status === 'error') {
       expect(strategyResult.code).toBe('MISSING_DEPENDENCIES_OR_WRONG_ORDER');
       if (strategyResult.code === 'MISSING_DEPENDENCIES_OR_WRONG_ORDER') {
-        expect(strategyResult.dependencies.join('\n')).toBe('');
+        expect(strategyResult.dependencies.join('\n')).toBe('graphicsApiReplacer');
       }
     }
   });

--- a/src/components/ucp-tabs/common/importing/import-strategies/tests/import-strategies.partly-valid.test.ts
+++ b/src/components/ucp-tabs/common/importing/import-strategies/tests/import-strategies.partly-valid.test.ts
@@ -1030,7 +1030,7 @@ describe('attemptStrategies', () => {
     if (strategyResult.status === 'error') {
       expect(strategyResult.code).toBe('MISSING_DEPENDENCIES_OR_WRONG_ORDER');
       if (strategyResult.code === 'MISSING_DEPENDENCIES_OR_WRONG_ORDER') {
-        expect(strategyResult.dependencies.join('\n')).toBe('');
+        expect(strategyResult.dependencies.join('\n')).toBe('graphicsApiReplacer');
       }
     }
   });

--- a/src/components/ucp-tabs/config-editor/ui-elements/ui-factory/CreateFileInput.tsx
+++ b/src/components/ucp-tabs/config-editor/ui-elements/ui-factory/CreateFileInput.tsx
@@ -24,7 +24,6 @@ import { useCurrentGameFolder } from '../../../../../function/game-folder/utils'
 import Logger from '../../../../../util/scripts/logging';
 import { showModalOkCancel } from '../../../../modals/modal-ok-cancel';
 import { getStore } from '../../../../../hooks/jotai/base';
-import { EXTENSION_STATE_REDUCER_ATOM } from '../../../../../function/extensions/state/state';
 import { parseEnabledLogic } from '../enabled-logic';
 import { formatToolTip } from '../tooltips';
 import ConfigWarning from './ConfigWarning';
@@ -35,6 +34,7 @@ import {
   CONFIGURATION_LOCKS_REDUCER_ATOM,
   CONFIGURATION_SUGGESTIONS_REDUCER_ATOM,
 } from '../../../../../function/configuration/derived-state';
+import { ACTIVE_EXTENSIONS_FULL_ATOM } from '../../../../../function/extensions/state/focus';
 
 const LOGGER = new Logger('CreateFileInput.tsx');
 
@@ -169,8 +169,8 @@ function CreateFileInput(args: {
 
           const isNotListed =
             getStore()
-              .get(EXTENSION_STATE_REDUCER_ATOM)
-              .activeExtensions.map((ex) => ex.name)
+              .get(ACTIVE_EXTENSIONS_FULL_ATOM)
+              .map((ex) => ex.name)
               .indexOf(extensionName) === -1;
           if (isNotListed) {
             if (

--- a/src/components/ucp-tabs/extension-manager/extension-elements/customize-extension-button-callback.ts
+++ b/src/components/ucp-tabs/extension-manager/extension-elements/customize-extension-button-callback.ts
@@ -117,6 +117,9 @@ export async function customizeExtensionButtonCallback(ext: Extension) {
       value: newConfigurationQualifier,
     });
 
+    /**
+     * Here the extension is set
+     */
     getStore().set(EXTENSION_EDITOR_STATE_ATOM, {
       extension: ext,
       state: 'active',

--- a/src/components/ucp-tabs/extension-manager/extension-manager.tsx
+++ b/src/components/ucp-tabs/extension-manager/extension-manager.tsx
@@ -33,9 +33,6 @@ const HAS_CUSTOMISATIONS = atom(
 export default function ExtensionManager() {
   const extensionsState = useAtomValue(EXTENSION_STATE_REDUCER_ATOM);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const extensionEditorState = useAtomValue(EXTENSION_EDITOR_STATE_ATOM);
-
   const showAllExtensions = useAtomValue(GuiSettings.SHOW_ALL_EXTENSIONS_ATOM);
 
   const displayedActiveExtensions = showAllExtensions

--- a/src/components/ucp-tabs/overview/installation/InstallationButton.tsx
+++ b/src/components/ucp-tabs/overview/installation/InstallationButton.tsx
@@ -89,7 +89,8 @@ export function InstallationButton() {
         isSuccess &&
         overviewButtonActive &&
         currentFolder !== '' &&
-        updateStatus.status !== 'no_update'
+        (updateStatus.status === 'update' ||
+          updateStatus.status === 'not_installed')
       }
       buttonText={buttonLabel}
       buttonVariant="ucp-button overview__text-button"
@@ -100,7 +101,11 @@ export function InstallationButton() {
 
         const updater = getStore().get(FRAMEWORK_UPDATER_ATOM);
 
-        if (updater === undefined) return;
+        if (updater === undefined) {
+          LOGGER.msg(`No updater object`).warn();
+
+          return;
+        }
 
         if (
           (updateStatus.status === 'no_update' &&

--- a/src/function/extensions/state/focus.ts
+++ b/src/function/extensions/state/focus.ts
@@ -2,12 +2,27 @@ import { focusAtom } from 'jotai-optics';
 import { atom } from 'jotai';
 import { EXTENSION_STATE_INTERFACE_ATOM } from './state';
 import { Extension } from '../../../config/ucp/common';
+import { EXTENSION_EDITOR_STATE_ATOM } from '../../../components/ucp-tabs/common/extension-editor/extension-editor-state';
 
 // eslint-disable-next-line import/prefer-default-export
 export const ACTIVE_EXTENSIONS_ATOM = focusAtom(
   EXTENSION_STATE_INTERFACE_ATOM,
   (optic) => optic.prop('activeExtensions'),
 );
+
+/**
+ * Prepends editor extension if relevant to active extensions list
+ */
+export const ACTIVE_EXTENSIONS_FULL_ATOM = atom<Extension[]>((get) => {
+  const activeExtensions = get(ACTIVE_EXTENSIONS_ATOM);
+  const editorState = get(EXTENSION_EDITOR_STATE_ATOM);
+
+  if (editorState.state === 'inactive') {
+    return activeExtensions;
+  }
+
+  return [editorState.extension, ...activeExtensions];
+});
 
 export const ACTIVE_EXTENSIONS_ID_ATOM = atom<string[]>((get) => {
   const result = get(ACTIVE_EXTENSIONS_ATOM).map(


### PR DESCRIPTION
- [X] Allow AI Swapper to know the currently edited extension
- [X] File Input doesn't warn about edited extension being not active
- [ ] Add "merge with top extension" button or something similar. Didn't we write the import button logic here to support this use case?